### PR TITLE
feat: Create get quote by id endpoint

### DIFF
--- a/src/modules/quote/application/exceptions/quote.error.enum.ts
+++ b/src/modules/quote/application/exceptions/quote.error.enum.ts
@@ -1,3 +1,6 @@
 export enum QuoteError {
   FAILED_TO_CREATE_QUOTE = 'Failed to create quote',
+  QUOTE_NOT_FOUND = 'Quote not found',
+  QUOTE_EXPIRED = 'Quote expired',
+  FAILED_TO_GET_QUOTE = 'Failed to get quote',
 }

--- a/src/modules/quote/application/mapper/response/quote.response.mapper.ts
+++ b/src/modules/quote/application/mapper/response/quote.response.mapper.ts
@@ -1,0 +1,15 @@
+import { currency } from '@/modules/quote/domain/currency.enum';
+import { Quote } from '@/modules/quote/domain/quote.domain';
+import { Quote as RepositoryQuote } from '@prisma/client';
+
+export class QuoteResponseMapper {
+  fromRepositoryToQuote(quote: RepositoryQuote): Quote {
+    const { createdAt, updatedAt, ...filteredQuote } = quote;
+
+    return new Quote({
+      ...filteredQuote,
+      from: currency[filteredQuote.from],
+      to: currency[filteredQuote.to],
+    });
+  }
+}

--- a/src/modules/quote/application/repository/quote.repository.ts
+++ b/src/modules/quote/application/repository/quote.repository.ts
@@ -3,5 +3,6 @@ import { Quote } from '../../domain/quote.domain';
 export const QUOTE_REPOSITORY = 'QUOTE_REPOSITORY';
 
 export interface QuoteRepository {
+  findOne(id: string): Promise<Quote>;
   create(quote: Quote): Promise<Quote>;
 }

--- a/src/modules/quote/application/service/__test__/quote.facade.spec.ts
+++ b/src/modules/quote/application/service/__test__/quote.facade.spec.ts
@@ -5,16 +5,25 @@ import { CreateQuoteDto } from '../../dto/create-quote.dto';
 import { currency } from '../../../domain/currency.enum';
 import { Quote } from '../../../domain/quote.domain';
 import { QUOTE_REPOSITORY } from '../../repository/quote.repository';
+import { QuoteError } from '../../exceptions/quote.error.enum';
+import {
+  ConflictException,
+  GoneException,
+  NotFoundException,
+} from '@nestjs/common';
+import * as crypto from 'node:crypto';
 
 describe('QuoteFacade', () => {
   let facade: QuoteFacade;
   let quoteService: QuoteService;
 
   const mockQuoteService = {
+    findOne: jest.fn(),
     create: jest.fn(),
   };
 
   const mockQuoteRepository = {
+    findOne: jest.fn(),
     create: jest.fn(),
   };
 
@@ -41,22 +50,54 @@ describe('QuoteFacade', () => {
     jest.clearAllMocks();
   });
 
+  const mockQuote: Quote = {
+    id: crypto.randomUUID(),
+    from: currency.USDC,
+    to: currency.CLP,
+    amount: 100,
+    rate: 850.5,
+    convertedAmount: 85050,
+    timestamp: new Date('2025-01-01'),
+    expiresAt: new Date('2025-01-01T00:05:00.000Z'),
+  };
+
+  describe('findOneQuote', () => {
+    it('should delegate quote retrieval to QuoteService', async () => {
+      mockQuoteService.findOne.mockResolvedValue(mockQuote);
+
+      const result = await facade.findOneQuote(mockQuote.id);
+
+      expect(quoteService.findOne).toHaveBeenCalledWith(mockQuote.id);
+      expect(result).toEqual(mockQuote);
+    });
+
+    it('should propagate error from QuoteService when quote is not found', async () => {
+      const error = new NotFoundException(QuoteError.QUOTE_NOT_FOUND);
+      mockQuoteService.findOne.mockRejectedValue(error);
+
+      await expect(facade.findOneQuote(mockQuote.id)).rejects.toThrow(error);
+    });
+
+    it('should propagate error from QuoteService when quote is expired', async () => {
+      const error = new GoneException(QuoteError.QUOTE_EXPIRED);
+      mockQuoteService.findOne.mockRejectedValue(error);
+
+      await expect(facade.findOneQuote(mockQuote.id)).rejects.toThrow(error);
+    });
+
+    it('should propagate error from QuoteService when failed to get quote', async () => {
+      const error = new ConflictException(QuoteError.FAILED_TO_GET_QUOTE);
+      mockQuoteService.findOne.mockRejectedValue(error);
+
+      await expect(facade.findOneQuote(mockQuote.id)).rejects.toThrow(error);
+    });
+  });
+
   describe('createQuote', () => {
     const createQuoteDto: CreateQuoteDto = {
       amount: 100,
       from: currency.USDC,
       to: currency.CLP,
-    };
-
-    const mockQuote: Quote = {
-      id: '123',
-      from: currency.USDC,
-      to: currency.CLP,
-      amount: 100,
-      rate: 850.5,
-      convertedAmount: 85050,
-      timestamp: new Date('2025-01-01'),
-      expiresAt: new Date('2025-01-01T00:05:00.000Z'),
     };
 
     it('should delegate quote creation to QuoteService', async () => {

--- a/src/modules/quote/application/service/quote.facade.ts
+++ b/src/modules/quote/application/service/quote.facade.ts
@@ -7,6 +7,10 @@ import { Quote } from '../../domain/quote.domain';
 export class QuoteFacade {
   constructor(private readonly quoteService: QuoteService) {}
 
+  async findOneQuote(id: string): Promise<Quote> {
+    return await this.quoteService.findOne(id);
+  }
+
   async createQuote(createQuoteDto: CreateQuoteDto): Promise<Quote> {
     return await this.quoteService.create(createQuoteDto);
   }

--- a/src/modules/quote/infrastructure/persistence/quote.repository.ts
+++ b/src/modules/quote/infrastructure/persistence/quote.repository.ts
@@ -2,10 +2,26 @@ import { Injectable } from '@nestjs/common';
 import { QuoteRepository as IQuoteRepository } from '../../application/repository/quote.repository';
 import { PrismaService } from '@/modules/common/infrastructure/prisma/prisma.service';
 import { Quote } from '../../domain/quote.domain';
+import { QuoteResponseMapper } from '../../application/mapper/response/quote.response.mapper';
 
 @Injectable()
 export class QuoteRepository implements IQuoteRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly quoteResponseMapper: QuoteResponseMapper,
+  ) {}
+
+  async findOne(id: string): Promise<Quote | null> {
+    const quote = await this.prisma.quote.findUnique({
+      where: { id },
+    });
+
+    if (!quote) {
+      return null;
+    }
+
+    return this.quoteResponseMapper.fromRepositoryToQuote(quote);
+  }
 
   async create(data: Quote): Promise<Quote> {
     await this.prisma.quote.create({

--- a/src/modules/quote/interface/quote.controller.ts
+++ b/src/modules/quote/interface/quote.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
 import { CreateQuoteDto } from '../application/dto/create-quote.dto';
 import { Quote } from '../domain/quote.domain';
 import { QuoteFacade } from '../application/service/quote.facade';
@@ -6,6 +13,13 @@ import { QuoteFacade } from '../application/service/quote.facade';
 @Controller('quote')
 export class QuoteController {
   constructor(private readonly quoteFacade: QuoteFacade) {}
+
+  @Get(':id')
+  async findOne(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<Quote> {
+    return await this.quoteFacade.findOneQuote(id);
+  }
 
   @Post()
   async create(@Body() createQuoteDto: CreateQuoteDto): Promise<Quote> {

--- a/src/modules/quote/quote.module.ts
+++ b/src/modules/quote/quote.module.ts
@@ -7,6 +7,7 @@ import { QuoteFacade } from './application/service/quote.facade';
 import { CommonModule } from '../common/common.module';
 import { QUOTE_REPOSITORY } from './application/repository/quote.repository';
 import { QuoteRepository } from './infrastructure/persistence/quote.repository';
+import { QuoteResponseMapper } from './application/mapper/response/quote.response.mapper';
 
 @Module({
   imports: [CommonModule],
@@ -14,6 +15,7 @@ import { QuoteRepository } from './infrastructure/persistence/quote.repository';
   providers: [
     QuoteService,
     QuoteFacade,
+    QuoteResponseMapper,
     {
       provide: EXCHANGE_RATE_PROVIDER,
       useClass: CryptomktProvider,


### PR DESCRIPTION
# Summary

This PR adds a new endpoint to retrieve a quote by its ID and enhances error handling with multiple validation checks.

# Details

- Introduced **GET /quotes/{id}** endpoint.
- Implemented error handling for:
    - **404 Not Found** → When the quote does not exist.
    - **410 Gone** → When the quote has expired.
    - **409 Conflict** → When the quote retrieval fails (general error).
- Updated test suite to cover these cases.