### PR TITLE
feat: Create login endpoint

### DIFF
--- a/src/modules/auth/application/dto/index.ts
+++ b/src/modules/auth/application/dto/index.ts
@@ -1,0 +1,2 @@
+export { CreateUserDto } from './create-user.dto';
+export { LoginUserDto } from './login-user.dto';

--- a/src/modules/auth/application/dto/login-user.dto.ts
+++ b/src/modules/auth/application/dto/login-user.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class LoginUserDto {
+  @IsEmail()
+  username: string;
+
+  @IsString()
+  password: string;
+}

--- a/src/modules/auth/application/exceptions/auth.error.enum.ts
+++ b/src/modules/auth/application/exceptions/auth.error.enum.ts
@@ -3,4 +3,5 @@ export enum AuthError {
   FAILED_TO_CREATE_USER = 'Failed to create user',
   FAILED_TO_FIND_USER = 'Failed to find user',
   USER_NOT_FOUND = 'User not found',
+  INVALID_CREDENTIALS = 'Invalid credentials',
 }

--- a/src/modules/auth/application/service/__test__/auth.service.spec.ts
+++ b/src/modules/auth/application/service/__test__/auth.service.spec.ts
@@ -1,11 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from '../auth.service';
 import { USER_REPOSITORY } from '../../repository/user.repository';
-import { CreateUserDto } from '../../dto/create-user.dto';
-import { ConflictException } from '@nestjs/common';
+import { CreateUserDto, LoginUserDto } from '../../dto';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { AuthError } from '../../exceptions/auth.error.enum';
 import { JwtService } from '@nestjs/jwt';
 import * as crypto from 'node:crypto';
+import * as bcrypt from 'bcrypt';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -15,8 +16,9 @@ describe('AuthService', () => {
     createUser: jest.fn(),
   };
 
+  const mockToken = 'mock.jwt.token';
   const mockJwtService = {
-    sign: jest.fn(),
+    sign: jest.fn().mockReturnValue(mockToken),
   };
 
   beforeEach(async () => {
@@ -80,15 +82,10 @@ describe('AuthService', () => {
       password: 'hashedPassword',
     };
 
-    const mockToken = 'mock.jwt.token';
-
-    beforeEach(() => {
-      mockJwtService.sign.mockReturnValue(mockToken);
-    });
-
     it('should create a user successfully', async () => {
       mockUserRepository.findOne.mockResolvedValue(null);
       mockUserRepository.createUser.mockResolvedValue(mockUser);
+      const normalizedUsername = createUserDto.username.toLowerCase().trim();
 
       const response = await service.createUser(createUserDto);
 
@@ -98,11 +95,11 @@ describe('AuthService', () => {
         token: mockToken,
       });
       expect(mockUserRepository.findOne).toHaveBeenCalledWith(
-        createUserDto.username,
+        normalizedUsername,
       );
       expect(mockUserRepository.createUser).toHaveBeenCalled();
       expect(mockJwtService.sign).toHaveBeenCalledWith({
-        username: mockUser.username,
+        username: normalizedUsername,
       });
     });
 
@@ -122,6 +119,57 @@ describe('AuthService', () => {
 
       await expect(service.createUser(createUserDto)).rejects.toThrow(
         new ConflictException(AuthError.FAILED_TO_CREATE_USER),
+      );
+    });
+  });
+
+  describe('login', () => {
+    const loginUserDto: LoginUserDto = {
+      username: 'test@example.com',
+      password: 'Test123!',
+    };
+
+    const mockUser = {
+      id: crypto.randomUUID(),
+      username: 'test@example.com',
+      password: bcrypt.hashSync('Test123!', 10),
+    };
+
+    it('should login a user successfully', async () => {
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      const normalizedUsername = loginUserDto.username.toLowerCase().trim();
+
+      const response = await service.login(loginUserDto);
+
+      expect(response).toEqual({
+        id: mockUser.id,
+        username: mockUser.username,
+        token: mockToken,
+      });
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith(
+        normalizedUsername,
+      );
+      expect(mockJwtService.sign).toHaveBeenCalledWith({
+        username: normalizedUsername,
+      });
+    });
+
+    it('should throw UnauthorizedException when user is not found', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.login(loginUserDto)).rejects.toThrow(
+        new UnauthorizedException(AuthError.INVALID_CREDENTIALS),
+      );
+    });
+
+    it('should throw UnauthorizedException when password is invalid', async () => {
+      mockUserRepository.findOne.mockResolvedValue({
+        ...mockUser,
+        password: bcrypt.hashSync('WrongPassword', 10),
+      });
+
+      await expect(service.login(loginUserDto)).rejects.toThrow(
+        new UnauthorizedException(AuthError.INVALID_CREDENTIALS),
       );
     });
   });

--- a/src/modules/auth/application/service/auth.facade.ts
+++ b/src/modules/auth/application/service/auth.facade.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CreateUserDto } from '../dto/create-user.dto';
+import { CreateUserDto, LoginUserDto } from '../dto';
 import { AuthService } from './auth.service';
 import { UserResponse } from '../interface/user-response.interface';
 
@@ -9,5 +9,9 @@ export class AuthFacade {
 
   async createUser(createUserDto: CreateUserDto): Promise<UserResponse> {
     return this.authService.createUser(createUserDto);
+  }
+
+  async login(loginUserDto: LoginUserDto): Promise<UserResponse> {
+    return this.authService.login(loginUserDto);
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -30,5 +30,6 @@ import { JwtStrategy } from './infrastructure/strategy/jwt.strategy';
       useClass: UserRepository,
     },
   ],
+  exports: [AuthFacade, JwtStrategy, PassportModule],
 })
 export class AuthModule {}

--- a/src/modules/auth/interface/auth.controller.ts
+++ b/src/modules/auth/interface/auth.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { CreateUserDto } from '../application/dto/create-user.dto';
 import { AuthFacade } from '../application/service/auth.facade';
 import { UserResponse } from '../application/interface/user-response.interface';
+import { LoginUserDto, CreateUserDto } from '../application/dto';
 
 @Controller('auth')
 export class AuthController {
@@ -10,5 +10,10 @@ export class AuthController {
   @Post('register')
   register(@Body() createUserDto: CreateUserDto): Promise<UserResponse> {
     return this.authFacade.createUser(createUserDto);
+  }
+
+  @Post('login')
+  login(@Body() loginUserDto: LoginUserDto): Promise<UserResponse> {
+    return this.authFacade.login(loginUserDto);
   }
 }

--- a/src/modules/quote/interface/__test__/quote.controller.spec.ts
+++ b/src/modules/quote/interface/__test__/quote.controller.spec.ts
@@ -15,6 +15,7 @@ import {
 } from '@nestjs/common';
 import { QuoteError } from '../../application/exceptions/quote.error.enum';
 import { QUOTE_REPOSITORY } from '../../application/repository/quote.repository';
+import { PassportModule } from '@nestjs/passport';
 import * as crypto from 'node:crypto';
 
 describe('QuoteController Integration Tests', () => {
@@ -32,6 +33,7 @@ describe('QuoteController Integration Tests', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
       controllers: [QuoteController],
       providers: [
         QuoteFacade,

--- a/src/modules/quote/interface/quote.controller.ts
+++ b/src/modules/quote/interface/quote.controller.ts
@@ -5,12 +5,15 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 import { CreateQuoteDto } from '../application/dto/create-quote.dto';
 import { Quote } from '../domain/quote.domain';
 import { QuoteFacade } from '../application/service/quote.facade';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('quote')
+@UseGuards(AuthGuard())
 export class QuoteController {
   constructor(private readonly quoteFacade: QuoteFacade) {}
 

--- a/src/modules/quote/quote.module.ts
+++ b/src/modules/quote/quote.module.ts
@@ -8,9 +8,10 @@ import { CommonModule } from '../common/common.module';
 import { QUOTE_REPOSITORY } from './application/repository/quote.repository';
 import { QuoteRepository } from './infrastructure/persistence/quote.repository';
 import { QuoteResponseMapper } from './application/mapper/response/quote.response.mapper';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [CommonModule],
+  imports: [CommonModule, AuthModule],
   controllers: [QuoteController],
   providers: [
     QuoteService,


### PR DESCRIPTION
# Summary
Implementation of the login endpoint to validate credentials and protection of quote routes using AuthGuard.

# Details
- Added `POST /auth/login` endpoint for user authentication
- Protected quote routes
- Added login tests for AuthController, AuthService and AuthFacade
- Updated quote controller tests to include PassportModule