### PR TITLE
feat: Remove mxn currency

### DIFF
--- a/src/modules/quote/domain/currency.enum.ts
+++ b/src/modules/quote/domain/currency.enum.ts
@@ -1,7 +1,6 @@
 export enum currency {
   ARS = 'ARS',
   CLP = 'CLP',
-  MXN = 'MXN',
   USDC = 'USDC',
   BTC = 'BTC',
   ETH = 'ETH',


### PR DESCRIPTION
# Summary

This PR removes MXN (Mexican Peso) from the supported currencies enum as it's no longer a required currency for our exchange rate operations.
